### PR TITLE
Remove trailing hyphen in erb files

### DIFF
--- a/jobs/broker-deregistrar/templates/run.sh
+++ b/jobs/broker-deregistrar/templates/run.sh
@@ -18,7 +18,7 @@ CF_SKIP_SSL_VALIDATION='<%= p("cf.skip_ssl_validation") %>'
     broker = link("servicebroker")
     broker_name = broker.p("name")
   end
--%>
+%>
 BROKER_NAME='<%= broker_name %>'
 
 echo "CF_API_URL=${CF_API_URL}"

--- a/jobs/broker-registrar/templates/run.sh
+++ b/jobs/broker-registrar/templates/run.sh
@@ -26,7 +26,7 @@ CF_SKIP_SSL_VALIDATION='<%= p("cf.skip_ssl_validation") %>'
     broker_username = broker.p("username")
     broker_password = broker.p("password")
   end
--%>
+%>
 BROKER_NAME='<%= broker_name %>'
 BROKER_URL='<%= broker_url %>'
 BROKER_USERNAME='<%= broker_username %>'


### PR DESCRIPTION
On PCF 1.8 it fails with the following error message:

```
Error filling in template '(unknown)' (line (unknown): broker-registrar/run.sh:29: syntax error, unexpected ';'
-; _erbout.concat "\nBROKER_NAME='"
^) (00:00:01)
```