### PR TITLE
Fix unbound variable error

### DIFF
--- a/jobs/broker-deregistrar/templates/run.sh
+++ b/jobs/broker-deregistrar/templates/run.sh
@@ -13,7 +13,7 @@ exec 2>&1
 export PATH=$PATH:/var/vcap/packages/jq/bin
 export PATH=$PATH:/var/vcap/packages/cf-cli/bin
 
-set -eo pipefail -u
+set -eo pipefail
 
 <% cf = nil; if_link("cf-admin-user") { |link| cf = link } -%>
 CF_API_URL=<%= esc(cf ? cf.p("api_url") : p("cf.api_url")) %>

--- a/jobs/broker-registrar/templates/run.sh
+++ b/jobs/broker-registrar/templates/run.sh
@@ -13,7 +13,7 @@ exec 2>&1
 export PATH=$PATH:/var/vcap/packages/jq/bin
 export PATH=$PATH:/var/vcap/packages/cf-cli/bin
 
-set -eo pipefail -u
+set -eo pipefail
 
 <% cf = nil; if_link("cf-admin-user") { |link| cf = link } -%>
 CF_API_URL=<%= esc(cf ? cf.p("api_url") : p("cf.api_url")) %>


### PR DESCRIPTION
Hi,

In this PR, I remove the -u option in Bash scripts, so that whenever the $service_names array is empty, there is no error like /var/vcap/jobs/broker-registrar/bin/run: line 86: service_names[@]: unbound variable.

Best